### PR TITLE
Implement error handling for OpenAI Chat completions

### DIFF
--- a/lib/get_commit_message_suggestion.ts
+++ b/lib/get_commit_message_suggestion.ts
@@ -1,4 +1,11 @@
 import { OpenAI } from "../deps.ts";
+import { ChatCompletion } from "https://deno.land/x/openai@1.3.0/mod.ts";
+
+interface CustomChatCompletion extends ChatCompletion {
+  error: {
+    message: string;
+  };
+}
 
 export const getCommitMessageSuggestion = async (
   openaiAccessToken: string,
@@ -19,16 +26,22 @@ export const getCommitMessageSuggestion = async (
     - commit messages 3 (日本語訳3)
   `;
 
-  const chatCompletion = await openAI.createChatCompletion({
+  const options = {
     model: model,
     messages: [
-      {
-        "role": "system",
-        "content": systemContent,
-      },
+      { "role": "system", "content": systemContent },
       { "role": "user", "content": `${diffText}` },
     ],
-  });
+  };
+
+  const chatCompletion = await openAI.createChatCompletion(
+    options,
+  ) as CustomChatCompletion;
+
+  if (chatCompletion.error) {
+    console.log(chatCompletion.error.message);
+    Deno.exit(1);
+  }
 
   return chatCompletion.choices[0].message.content;
 };


### PR DESCRIPTION
```
$ cg
error: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
  return chatCompletion.choices[0].message.content;
                               ^
    at getCommitMessageSuggestion (https://deno.land/x/commit_genius@v0.4.0/lib/get_commit_message_suggestion.ts:33:32)
    at eventLoopTick (ext:core/01_core.js:166:11)
    at async MainCommand.fn (https://deno.land/x/commit_genius@v0.4.0/commands/main.ts:34:41)
    at async MainCommand.execute (https://deno.land/x/cliffy@v0.25.7/command/command.ts:1794:7)
    at async MainCommand.parseCommand (https://deno.land/x/cliffy@v0.25.7/command/command.ts:1639:14)
```

```
{
  error: {
    message: "This model's maximum context length is 4097 tokens. However, your messages resulted in 7648 tokens. ...",
    type: "invalid_request_error",
    param: "messages",
    code: "context_length_exceeded"
  }
}
```